### PR TITLE
Post-Level Summary Screen

### DIFF
--- a/Scenes/EndOfLevel.tscn
+++ b/Scenes/EndOfLevel.tscn
@@ -1,0 +1,93 @@
+[gd_scene load_steps=2 format=3 uid="uid://y5i2gkunbxmu"]
+
+[ext_resource type="Script" path="res://Scripts/EndOfLevel.gd" id="1_wmvg0"]
+
+[node name="EndOfLevel" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 1.0
+offset_right = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_wmvg0")
+
+[node name="WinLoseLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -53.5
+offset_top = -311.0
+offset_right = 55.5
+offset_bottom = -288.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "You Winnered"
+
+[node name="CaptionLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 412.0
+offset_top = 202.0
+offset_right = 886.0
+offset_bottom = 225.0
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="GotoMainMenuButton" type="Button" parent="."]
+layout_mode = 0
+offset_left = 608.0
+offset_top = 805.0
+offset_right = 807.0
+offset_bottom = 867.0
+text = "Main Menu"
+
+[node name="VariableLabelsGroup" type="Control" parent="."]
+visible = false
+anchors_preset = 0
+offset_left = 287.0
+offset_top = 265.0
+offset_right = 1023.0
+offset_bottom = 773.0
+
+[node name="BulletsShotTextLabel" type="Label" parent="VariableLabelsGroup"]
+visible = false
+layout_mode = 0
+offset_left = 559.0
+offset_top = 310.0
+offset_right = 708.0
+offset_bottom = 341.0
+text = "Bullets Shot:"
+vertical_alignment = 1
+
+[node name="BulletsShotValueLabel" type="Label" parent="VariableLabelsGroup"]
+visible = false
+layout_mode = 0
+offset_left = 723.0
+offset_top = 306.0
+offset_right = 897.0
+offset_bottom = 346.0
+text = "70
+"
+vertical_alignment = 1
+
+[node name="AccuracyTextLabel" type="Label" parent="VariableLabelsGroup"]
+visible = false
+layout_mode = 0
+offset_left = 550.0
+offset_top = 559.0
+offset_right = 724.0
+offset_bottom = 665.0
+
+[node name="AccuracyValueLabel" type="Label" parent="VariableLabelsGroup"]
+visible = false
+layout_mode = 0
+offset_left = 775.0
+offset_top = 591.0
+offset_right = 949.0
+offset_bottom = 697.0
+
+[node name="Timer" type="Timer" parent="."]

--- a/Scenes/LevelUI.tscn
+++ b/Scenes/LevelUI.tscn
@@ -116,6 +116,14 @@ offset_bottom = 299.0
 text = "Shoot Bullet
 "
 
+[node name="WinButton" type="Button" parent="TestButtons"]
+layout_mode = 0
+offset_left = 1019.0
+offset_top = 325.0
+offset_right = 1169.0
+offset_bottom = 376.0
+text = "Win Button"
+
 [node name="EquippedGunNameLabel" type="Label" parent="."]
 layout_mode = 0
 offset_left = 951.0

--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=2 format=3 uid="uid://vienf5h5i27g"]
+
+[ext_resource type="Script" path="res://Scripts/MainMenu.gd" id="1_5miqf"]
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_5miqf")
+
+[node name="GameTitleLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 224.0
+offset_top = 248.0
+offset_right = 1087.0
+offset_bottom = 450.0
+text = "THE GAME"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="PressFartLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 562.0
+offset_top = 490.0
+offset_right = 764.0
+offset_bottom = 513.0
+text = "PRESS FART TO CONTINUE"
+
+[node name="FartButton" type="Button" parent="."]
+layout_mode = 0
+offset_left = 546.0
+offset_top = 543.0
+offset_right = 793.0
+offset_bottom = 637.0
+text = "Fart"

--- a/Scripts/EndOfLevel.gd
+++ b/Scripts/EndOfLevel.gd
@@ -1,0 +1,147 @@
+extends Control
+
+@onready var global := get_node("/root/GlobalState")
+@onready var main_menu_button := $GotoMainMenuButton
+@onready var win_lose_label := $WinLoseLabel
+@onready var caption_label := $CaptionLabel
+@onready var variable_labels_group := $VariableLabelsGroup
+@onready var timer := $Timer
+
+var label_stack := []
+var accuracy_bonus := 0.0
+var net_gains := 420.0
+
+signal finished
+
+func _ready() -> void:
+	var bill_subtotal: float = float(global.bullet_counter["pea_shooter"]) * global.pea_shooter_gun["bulletcost"] + float(global.bullet_counter["bigger_gun"]) * global.bigger_gun["bulletcost"]
+	accuracy_bonus = global.get_accuracy() * 5.0
+	net_gains = accuracy_bonus - bill_subtotal
+	global.add_money(net_gains)
+	print("Net Gains: %.2f" % net_gains)
+	print("Bill Subtotal: $%.2f" % bill_subtotal)
+
+	main_menu_button.button_down.connect(on_main_menu_button_pressed)
+	timer.timeout.connect(on_timer_tick)
+	finished.connect(on_finished)
+
+	match global.end_screen_state:
+		global.EndScreenState.VICTORY:
+			win_lose_label.text = "YOU WIN"
+			caption_label.text = "All the debt owed was paid. Contract passed."
+		global.EndScreenState.DEFEAT:
+			win_lose_label.text = "YOU LOSE"
+			caption_label.text = "The owed debt was unable to be repaid. Contract Failed."
+		global.EndScreenState.YOU_DIED:
+			win_lose_label.text = "YOU DIED"
+			caption_label.text = "You were killed in action. Now your relatives inherit your debt."
+
+	init_label_positions()
+
+	timer.wait_time = 0.5
+	timer.start()
+
+# programatically create the labels for the statistics and put them on a stack
+func init_label_positions() -> void:
+	const x_offset := 200
+	const x_indent := 16
+	var x_start := size.x / 3 + 66
+	var current_pos :=  Vector2(x_start, size.y / 3)
+	var next_label: Label = create_new_label(current_pos, Color.WHITE, "Bullets Fired:")
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(current_pos.x + next_label.size.x + x_offset, current_pos.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "%d" % global.bullet_counter["total"])
+	label_stack.push_back(next_label)
+
+	if global.bullet_counter["pea_shooter"] > 0:
+		current_pos = Vector2(x_start + x_indent, current_pos.y + next_label.size.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "Pea Shooter:")
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + x_offset, current_pos.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "%d" % global.bullet_counter["pea_shooter"])
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + 2 * x_indent, current_pos.y + next_label.size.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "%d x $%.2f:" % [global.bullet_counter["pea_shooter"], global.pea_shooter_gun["bulletcost"]])
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + x_offset, current_pos.y)
+		next_label = create_new_label(current_pos, Color.DARK_RED, "$%.2f" % float(-global.bullet_counter["pea_shooter"] * global.pea_shooter_gun["bulletcost"]))
+		label_stack.push_back(next_label)
+
+	if global.bullet_counter["bigger_gun"] > 0:
+		current_pos = Vector2(x_start + x_indent, current_pos.y + next_label.size.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "Bigger Gun:")
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + x_offset, current_pos.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "%d" % global.bullet_counter["bigger_gun"])
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + 2 * x_indent, current_pos.y + next_label.size.y)
+		next_label = create_new_label(current_pos, Color.WHITE, "%d x $%.2f:" % [global.bullet_counter["bigger_gun"], global.bigger_gun["bulletcost"]])
+		label_stack.push_back(next_label)
+
+		current_pos = Vector2(x_start + x_offset, current_pos.y)
+		next_label = create_new_label(current_pos, Color.DARK_RED, "$%.2f" % float(-global.bullet_counter["bigger_gun"] * global.bigger_gun["bulletcost"]))
+		label_stack.push_back(next_label)
+
+	current_pos = Vector2(x_start, current_pos.y + 2 * next_label.size.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "Accuracy:")
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(current_pos.x + next_label.size.x + x_offset, current_pos.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "%.2f%%" % global.get_accuracy())
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(x_start + 2 * x_indent, current_pos.y + next_label.size.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "Accuracy Bonus:")
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(x_start + x_offset, current_pos.y)
+	next_label = create_new_label(current_pos, Color.WEB_GREEN, "$%.2f" % accuracy_bonus)
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(x_start, current_pos.y + 2 * next_label.size.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "Net Gains:")
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(current_pos.x + next_label.size.x + x_offset, current_pos.y)
+	var net_gains_color := Color.WEB_GREEN if net_gains > 0.0 else Color.DARK_RED
+	next_label = create_new_label(current_pos, net_gains_color, "$%.2f" % net_gains)
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(x_start, current_pos.y + 2 * next_label.size.y)
+	next_label = create_new_label(current_pos, Color.WHITE, "Your Money:")
+	label_stack.push_back(next_label)
+
+	current_pos = Vector2(current_pos.x + next_label.size.x + x_offset, current_pos.y)
+	var total_money_color := Color.WEB_GREEN if global.money > 0.0 else Color.DARK_RED
+	next_label = create_new_label(current_pos, total_money_color, "$%.2f" % global.money)
+	label_stack.push_back(next_label)
+
+# helper to generate label nodes
+func create_new_label(pos: Vector2, color: Color, text: String) -> Label:
+	var new_label := Label.new()
+	new_label.add_theme_color_override("font_color", color)
+	new_label.position = pos
+	new_label.text = text
+	#print("New Label\n\tPos: [%d, %d]\n\tSize: [%d, %d]\n\tText: %s" % [new_label.position.x, new_label.position.y, new_label.size.x, new_label.size.y, new_label.text])
+	return new_label
+
+# every timer tick, pop the label stack and display that label
+func on_timer_tick() -> void:
+	if len(label_stack) < 1:
+		finished.emit()
+		return
+	var front: Label = label_stack.front()
+	label_stack = label_stack.slice(1, len(label_stack))
+	add_child(front)
+
+func on_main_menu_button_pressed() -> void:
+	global.goto_main_menu(self)
+
+func on_finished() -> void:
+	timer.stop()

--- a/Scripts/Enemy.gd
+++ b/Scripts/Enemy.gd
@@ -50,6 +50,7 @@ func remove_self() -> void:
 
 func _on_area_entered(area: Area2D) -> void:
 	if area.is_in_group("player_bullet"):
+		globals.hit_count += 1
 		enemy_hit.emit()
 		area.enable(false)
 

--- a/Scripts/GunShop.gd
+++ b/Scripts/GunShop.gd
@@ -10,6 +10,6 @@ func _ready():
 	update_labels()
 
 func update_labels():
-	gun_name.text = global.current_purchasable_gun["name"]
-	gun_price.text = "$%.2f" % global.current_purchasable_gun["shopprice"]
-	gun_bullet_cost.text = "$%.2f" % global.current_purchasable_gun["bulletcost"]
+	gun_name.text = global.current_purchasable_weapon["name"]
+	gun_price.text = "$%.2f" % global.current_purchasable_weapon["shopprice"]
+	gun_bullet_cost.text = "$%.2f" % global.current_purchasable_weapon["bulletcost"]

--- a/Scripts/LevelUI.gd
+++ b/Scripts/LevelUI.gd
@@ -7,6 +7,8 @@ extends Control
 @onready var shop_gun_name := $EquippedGunNameLabel
 @onready var equipped_gun_value := $EquippedGunValueLabel
 
+@onready var win_button := $TestButtons/WinButton
+
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("buy_share"):
 		on_buy_share_pressed()
@@ -19,7 +21,9 @@ func _ready() -> void:
 	global.money_added.connect(update_money_label)
 	money_value.text = "$%.2f" % global.money
 	money_value.add_theme_color_override("font_color", Color.WEB_GREEN)
-	accuracy_value.text = "%.2f%%" % global.accuracy
+	accuracy_value.text = "%.2f%%" % global.get_accuracy()
+	win_button.button_down.connect(on_win_button_pressed)
+	global.player_died.connect(on_player_died)
 
 #  TODO: proper detection on a bullet collision is a priority
 func on_shoot_button() -> void:
@@ -59,4 +63,10 @@ func on_buy_gun_pressed() -> void:
 		update_equipped_gun_label()
 	# TODO: maybe play an animation when funds are insufficient
 
+func on_win_button_pressed() -> void:
+	global.end_screen_state = global.EndScreenState.VICTORY
+	global.goto_end_screen(get_parent())
 
+func on_player_died():
+	global.end_screen_state = global.EndScreenState.YOU_DIED
+	global.goto_end_screen(get_parent())

--- a/Scripts/MainMenu.gd
+++ b/Scripts/MainMenu.gd
@@ -1,0 +1,11 @@
+extends Control
+
+@onready var start_button := $FartButton
+
+func _ready() -> void:
+	start_button.button_down.connect(on_start_button_pressed)
+
+func on_start_button_pressed() -> void:
+	var next_scene := preload("res://Scenes/TestLevel.tscn").instantiate()
+	get_tree().root.add_child(next_scene)
+	self.queue_free()

--- a/Scripts/PlayerController.gd
+++ b/Scripts/PlayerController.gd
@@ -52,6 +52,7 @@ func fire() -> void:
 	b.lifetime = 2
 	b.rotation = -PI/2 # Rotate 90 degrees for upward firing
 
+	globals.update_bullet_counter()
 	can_fire = false
 	shot_timer.start()
 


### PR DESCRIPTION
Once the level is complete/failed/died, the level scene is destroyed and a summary UI scene is created with a "You Win/Lose/Died" message at the top.

The player's stats are calculated and billed accordingly. The labels for each item are generated programmatically for most flexibilty and appear in sequence on a timer.