### PR TITLE
Fix: web export build not able to hear music

### DIFF
--- a/Scripts/EndOfLevel.gd
+++ b/Scripts/EndOfLevel.gd
@@ -7,7 +7,7 @@ extends Control
 @onready var timer := $Timer
 
 @onready var audio_manager := get_node("/root/AudioManager")
-@onready var soundtrack := AudioStreamOggVorbis.load_from_file("res://Resources/Audio/Music/Reonidas.ogg")
+@onready var soundtrack := preload("res://Resources/Audio/Music/Reonidas.ogg")
 
 var label_stack := []
 var accuracy_bonus := 0.0

--- a/Scripts/Level1.gd
+++ b/Scripts/Level1.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 @onready var audio_manager := get_node("/root/AudioManager")
-@onready var soundtrack := AudioStreamOggVorbis.load_from_file("res://Resources/Audio/Music/Tsumi.ogg")
+@onready var soundtrack := preload("res://Resources/Audio/Music/Tsumi.ogg")
 
 const LEVEL = preload("res://Scripts/Level.gd")
 @onready var globals := $'/root/GlobalState'

--- a/Scripts/Level2.gd
+++ b/Scripts/Level2.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 @onready var audio_manager := get_node("/root/AudioManager")
-@onready var soundtrack := AudioStreamOggVorbis.load_from_file("res://Resources/Audio/Music/Tsumi.ogg")
+@onready var soundtrack := preload("res://Resources/Audio/Music/BetsAreOff.ogg")
 
 const LEVEL = preload("res://Scripts/Level.gd")
 @onready var globals := $'/root/GlobalState'

--- a/Scripts/MainMenu.gd
+++ b/Scripts/MainMenu.gd
@@ -4,7 +4,7 @@ extends Control
 @onready var globals := get_node("/root/GlobalState")
 
 func _ready() -> void:
-	var main_menu_song := AudioStreamOggVorbis.load_from_file("res://Resources/Audio/Music/Reonidas.ogg")
+	var main_menu_song := preload("res://Resources/Audio/Music/Reonidas.ogg")
 	audio_manager.set_soundtrack(main_menu_song)
 	audio_manager.play_soundtrack()
 

--- a/Scripts/TestLevel.gd
+++ b/Scripts/TestLevel.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 @onready var audio_manager := get_node("/root/AudioManager")
-@onready var soundtrack := AudioStreamOggVorbis.load_from_file("res://Resources/Audio/Music/Tsumi.ogg")
+@onready var soundtrack := preload("res://Resources/Audio/Music/Tsumi.ogg")
 
 const LEVEL = preload("res://Scripts/Level.gd")
 @onready var globals := $'/root/GlobalState'

--- a/audio_manager.gd
+++ b/audio_manager.gd
@@ -22,9 +22,8 @@ func _ready() -> void:
 	player_sfx_player.max_polyphony = 10
 	add_child(player_sfx_player)
 
-func set_soundtrack(stream: AudioStreamOggVorbis) -> void:
-	soundtrack_player.stream = stream
-	soundtrack_player.stream.loop = true
+func set_soundtrack(s: Resource) -> void:
+	soundtrack_player.stream = s
 
 func play_soundtrack() -> void:
 	soundtrack_player.playing = true


### PR DESCRIPTION
Using AudioStreamOggVorbis.load_from_file() does not seem to be supported. Using preload() instead.